### PR TITLE
Add github action to add hacktoberfest label to PR and issues

### DIFF
--- a/.github/workflows/hacktoberfest-labeler.yml
+++ b/.github/workflows/hacktoberfest-labeler.yml
@@ -1,0 +1,38 @@
+name: Hacktoberfest Labeler
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-hacktoberfest-label:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Add Hacktoberfest label to new issues
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: ['hacktoberfest']
+            });
+
+      - name: Add Hacktoberfest label to new pull requests
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['hacktoberfest']
+            });


### PR DESCRIPTION
Fixes #8 

Changes Made:
- Complete GitHub Actions workflow for automatic Hacktoberfest labeling on Pull Requests and Issues.